### PR TITLE
Fixed: Dependencies installable from setup.py

### DIFF
--- a/mediawikiapi/__init__.py
+++ b/mediawikiapi/__init__.py
@@ -1,7 +1,10 @@
-from .config import *
-from .mediawikiapi import *
-from .exceptions import *
-from .language import *
+import sys
+
+if not sys.argv[0] == 'pip' and not sys.argv[1] == 'setup.py':
+    from .config import *
+    from .mediawikiapi import *
+    from .exceptions import *
+    from .language import *
 
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/mediawikiapi/__init__.py
+++ b/mediawikiapi/__init__.py
@@ -4,4 +4,4 @@ from .exceptions import *
 from .language import *
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/mediawikiapi/mediawikiapi.py
+++ b/mediawikiapi/mediawikiapi.py
@@ -152,7 +152,7 @@ class MediaWikiAPI(object):
     '''
     # use auto_suggest and redirect to get the correct article
     # also, use page's error checking to raise DisambiguationError if necessary
-    page_info = page(title, auto_suggest=auto_suggest, redirect=redirect)
+    page_info = self.page(title, auto_suggest=auto_suggest, redirect=redirect)
     title = page_info.title
     pageid = page_info.pageid
     query_params = {


### PR DESCRIPTION
Conditionally import other files in `__init__.py` so setup.py can be run without installing dependencies first.