### PR TITLE
Fix missing cases from #12

### DIFF
--- a/mediawikiapi/__init__.py
+++ b/mediawikiapi/__init__.py
@@ -1,6 +1,8 @@
 import sys
 
-if not (sys.argv[0] in ['pip', 'setup.py'] or (len(sys.argv) > 1 and sys.argv[1] in ['setup.py', 'egg_info'])):
+if not (sys.argv[0] in ['pip', 'setup.py']
+        or (len(sys.argv) > 1 and sys.argv[1] == 'setup.py')
+        or (len(sys.argv) > 1 and sys.argv[0] == '-c' and sys.argv[1] in ['egg_info', 'clean', 'bdist_wheel', 'sdist', 'install'])):
     from .config import *
     from .mediawikiapi import *
     from .exceptions import *

--- a/mediawikiapi/__init__.py
+++ b/mediawikiapi/__init__.py
@@ -1,10 +1,9 @@
 import sys
 
-if not (sys.argv[0] == 'pip' or (len(sys.argv) > 1 and sys.argv[1] == 'setup.py')):
+if not (sys.argv[0] in ['pip', 'setup.py'] or (len(sys.argv) > 1 and sys.argv[1] in ['setup.py', 'egg_info'])):
     from .config import *
     from .mediawikiapi import *
     from .exceptions import *
     from .language import *
-
 
 __version__ = "1.1.2"

--- a/mediawikiapi/__init__.py
+++ b/mediawikiapi/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-if not sys.argv[0] == 'pip' and not sys.argv[1] == 'setup.py':
+if not (sys.argv[0] == 'pip' or (len(sys.argv) > 1 and sys.argv[1] == 'setup.py')):
     from .config import *
     from .mediawikiapi import *
     from .exceptions import *


### PR DESCRIPTION
I missed checking the length of `sys.argv` in #12, so import would fail if there was only one argument. I think this is an edge case since you'd usually have the name of the script in the first place if running with `python`, but I think it could happen if you `#!/usr/bin/python` in a script or create an application with scripts in setup.py.