### PR TITLE
Check links list access if empty

### DIFF
--- a/mediawikiapi/wikipediapage.py
+++ b/mediawikiapi/wikipediapage.py
@@ -116,13 +116,15 @@ class WikipediaPage(object):
       disambiguation = []
       host_name = page["fullurl"]
       for lis_item in filtered_lis:
-        item = lis_item.find_all("a")[0]
-        one_disambiguation = {}
-        one_disambiguation["title"] = item["title"]
-        one_disambiguation["host_name"] = host_name
-        one_disambiguation["href"] = item["href"]
-        one_disambiguation["description"] = lis_item.text
-        disambiguation.append(one_disambiguation)
+        items = lis_item.find_all("a")
+        if items:
+          item = items[0]
+          one_disambiguation = {}
+          one_disambiguation["title"] = item["title"]
+          one_disambiguation["host_name"] = host_name
+          one_disambiguation["href"] = item["href"]
+          one_disambiguation["description"] = lis_item.text
+          disambiguation.append(one_disambiguation)
       may_refer_to = [li.a.get_text() for li in filtered_lis if li.a]
       raise DisambiguationError(getattr(self, 'title', page['title']), may_refer_to, disambiguation)
 


### PR DESCRIPTION
I was running into an `IndexError` here due to `lis_item.find_all("a")` returning an empty list, so this just adds a check that that isn't empty. I'm not sure if this fix could affect anything else, but it has fixed my issue.

For reference, here are some of the pages that caused this issue:
https://en.wikipedia.org/wiki/Avant
https://en.wikipedia.org/wiki/28_Days
https://en.wikipedia.org/wiki/The_Squires_(disambiguation)

I will say that all of these are disambiguation pages that I'm trying to query with `MediaWikiAPI().summary('Avant')` and similar, though I'd think I'd just normally get a `DisambiguationError`. Please let me know if this type of query actually isn't supported and I need to handle it on my application's side.